### PR TITLE
Implement basic job-matching demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # koptest
-KOPのMVP機能でやってみる
+
+This project demonstrates a simple job matching MVP using FastAPI and OpenAI.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set the `OPENAI_API_KEY` environment variable and run the server:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+Open `frontend/index.html` in your browser to use the demo UI.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # koptest
 
-This project demonstrates a simple job matching MVP using FastAPI and OpenAI.
+FastAPI と OpenAI を利用した簡易ジョブマッチングのデモプロジェクトです。
 
-## Setup
+## セットアップ
 
-Install dependencies:
+依存パッケージのインストール:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-Set the `OPENAI_API_KEY` environment variable and run the server:
+環境変数 `OPENAI_API_KEY` を設定し、サーバーを起動します:
 
 ```bash
 uvicorn backend.main:app --reload
 ```
 
-Open `frontend/index.html` in your browser to use the demo UI.
+ブラウザで `frontend/index.html` を開くとデモ UI を利用できます。

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,45 @@
+import os
+from fastapi import FastAPI
+from pydantic import BaseModel
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = FastAPI()
+
+class TextIn(BaseModel):
+    text: str
+
+class MatchIn(BaseModel):
+    jobs_csv: str
+    seekers_csv: str
+
+@app.post("/process_jobs")
+async def process_jobs(data: TextIn):
+    prompt = f"""以下のテキストを整理してCSV形式で出力してください。\nカラムは会社名,求人概要,希望スキルです。\n\n### 入力\n{data.text}\n"""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    csv_text = response.choices[0].message.content.strip()
+    return {"csv": csv_text}
+
+@app.post("/process_seekers")
+async def process_seekers(data: TextIn):
+    prompt = f"""以下の求職者プロフィールを整理してCSV形式で出力してください。\nカラムは基本情報（名前・年齢）,スキル,希望です。\n\n### 入力\n{data.text}\n"""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    csv_text = response.choices[0].message.content.strip()
+    return {"csv": csv_text}
+
+@app.post("/match")
+async def match(data: MatchIn):
+    prompt = f"""以下の求人CSVと求職者CSVを基にマッチングを行ってください。\n求人CSV:\n{data.jobs_csv}\n\n求職者CSV:\n{data.seekers_csv}\n\n結果は次のフォーマットでCSV出力してください:\n求職者名,マッチ求人,相性スコア（1〜100）,コメント\n"""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    csv_text = response.choices[0].message.content.strip()
+    return {"csv": csv_text}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>Job Matching Demo</title>
+<style>
+.tab { display:none; }
+.active { display:block; }
+</style>
+</head>
+<body>
+<button onclick="showTab('jobs')">求人データ</button>
+<button onclick="showTab('seekers')">求職者データ</button>
+<button onclick="showTab('match')">マッチング結果</button>
+
+<div id="jobs" class="tab">
+  <h3>求人データ入力</h3>
+  <textarea id="jobsInput" rows="10" cols="60"></textarea><br>
+  <button onclick="processJobs()">整理</button>
+  <pre id="jobsCsv"></pre>
+</div>
+
+<div id="seekers" class="tab">
+  <h3>求職者データ入力</h3>
+  <textarea id="seekersInput" rows="10" cols="60"></textarea><br>
+  <button onclick="processSeekers()">整理</button>
+  <pre id="seekersCsv"></pre>
+</div>
+
+<div id="match" class="tab">
+  <h3>マッチング</h3>
+  <button onclick="runMatch()">マッチ実行</button>
+  <pre id="matchCsv"></pre>
+</div>
+
+<script>
+let jobsCsv = "";
+let seekersCsv = "";
+function showTab(id) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+}
+async function processJobs() {
+  const text = document.getElementById('jobsInput').value;
+  const res = await fetch('/process_jobs', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text})});
+  const data = await res.json();
+  jobsCsv = data.csv;
+  document.getElementById('jobsCsv').textContent = jobsCsv;
+}
+async function processSeekers() {
+  const text = document.getElementById('seekersInput').value;
+  const res = await fetch('/process_seekers', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text})});
+  const data = await res.json();
+  seekersCsv = data.csv;
+  document.getElementById('seekersCsv').textContent = seekersCsv;
+}
+async function runMatch() {
+  const res = await fetch('/match', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({jobs_csv: jobsCsv, seekers_csv: seekersCsv})});
+  const data = await res.json();
+  document.getElementById('matchCsv').textContent = data.csv;
+}
+showTab('jobs');
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+openai


### PR DESCRIPTION
## Summary
- create FastAPI backend with three OpenAI-powered endpoints
- add minimal browser UI with tabs for job input, seeker input, and matching
- document setup steps in README
- add requirements and gitignore

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m compileall -q backend`


------
https://chatgpt.com/codex/tasks/task_e_684900c450488329a8bbbfc32f4e3d18