### PR TITLE
Improve API key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace with your OpenAI API key
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ FastAPI と OpenAI を利用した簡易ジョブマッチングのデモプロ�
 pip install -r requirements.txt
 ```
 
-環境変数 `OPENAI_API_KEY` を設定し、サーバーを起動します:
+環境変数 `OPENAI_API_KEY` を設定し、サーバーを起動します。 `.env` ファイルを用意してキーを記入しておくこともできます:
 
 ```bash
+echo "OPENAI_API_KEY=your-key" > .env
 uvicorn backend.main:app --reload
 ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,9 @@ import os
 from fastapi import FastAPI
 from pydantic import BaseModel
 import openai
+from dotenv import load_dotenv
+
+load_dotenv()
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 openai
+python-dotenv


### PR DESCRIPTION
## Summary
- support dotenv file in backend
- add example dotenv file
- mention `.env` usage in README
- include python-dotenv in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684902bb05f483299f54acf2955a8f0a