### PR TITLE
Fix 404 error by serving frontend index

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import os
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 import openai
 from dotenv import load_dotenv
@@ -9,6 +10,16 @@ load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI()
+
+# Serve the demo UI at the root path
+@app.get("/")
+async def read_index():
+    return FileResponse("frontend/index.html")
+
+# Dummy empty response for favicon requests
+@app.get("/favicon.ico")
+async def favicon():
+    return Response(status_code=204)
 
 class TextIn(BaseModel):
     text: str


### PR DESCRIPTION
## Summary
- serve `frontend/index.html` from `/`
- handle `/favicon.ico` with empty response

## Testing
- `python -m py_compile backend/main.py`
- `pip install -q -r requirements.txt`
- `uvicorn backend.main:app --reload &` *(server start)*
- `curl -i http://127.0.0.1:8000/`
- `curl -i http://127.0.0.1:8000/favicon.ico`


------
https://chatgpt.com/codex/tasks/task_e_684918b672988329b06e9c79a05d07db