### PR TITLE
Enable file uploads for matching data

### DIFF
--- a/frontend/app/api/match/route.ts
+++ b/frontend/app/api/match/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 
 export async function POST(request: NextRequest) {
   try {
-    const { jobs, applicant } = await request.json()
+    const { jobs_csv, seekers_csv } = await request.json()
 
     // FastAPI バックエンドへのリクエスト
     const response = await fetch(`${process.env.FASTAPI_URL}/match`, {
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ jobs, applicant }),
+      body: JSON.stringify({ jobs_csv, seekers_csv }),
     })
 
     if (!response.ok) {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Textarea } from "@/components/ui/textarea"
+import * as XLSX from "xlsx"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -35,32 +35,62 @@ interface MatchResult {
 
 export default function JobMatchingApp() {
   const [activeTab, setActiveTab] = useState("jobs")
-  const [jobText, setJobText] = useState("")
-  const [applicantText, setApplicantText] = useState("")
+  const [jobFile, setJobFile] = useState<File | null>(null)
+  const [applicantFile, setApplicantFile] = useState<File | null>(null)
   const [jobData, setJobData] = useState<JobData[]>([])
   const [applicantData, setApplicantData] = useState<ApplicantData[]>([])
   const [matchResults, setMatchResults] = useState<MatchResult[]>([])
+  const [jobsCsv, setJobsCsv] = useState("")
+  const [seekersCsv, setSeekersCsv] = useState("")
+  const [matchJobsFile, setMatchJobsFile] = useState<File | null>(null)
+  const [matchSeekersFile, setMatchSeekersFile] = useState<File | null>(null)
   const [isJobProcessing, setIsJobProcessing] = useState(false)
   const [isApplicantProcessing, setIsApplicantProcessing] = useState(false)
   const [isMatching, setIsMatching] = useState(false)
   const [showMatchResults, setShowMatchResults] = useState(false)
 
+  const readUpload = async (file: File | null) => {
+    if (!file) return null
+    const ext = file.name.split('.').pop()?.toLowerCase()
+    if (ext === 'txt' || ext === 'csv') {
+      return await file.text()
+    } else if (ext === 'xlsx' || ext === 'xls') {
+      const data = await file.arrayBuffer()
+      const wb = XLSX.read(data, { type: 'array' })
+      const sheet = wb.Sheets[wb.SheetNames[0]]
+      return XLSX.utils.sheet_to_csv(sheet)
+    } else {
+      alert('対応していないファイル形式です')
+      return null
+    }
+  }
+
   const processJobData = async () => {
-    if (!jobText.trim()) return
+    if (!jobFile) return
+    const text = await readUpload(jobFile)
+    if (!text) return
 
     setIsJobProcessing(true)
     try {
-      const response = await fetch("/api/process-jobs", {
+    const response = await fetch("/api/process-jobs", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ text: jobText }),
+        body: JSON.stringify({ text }),
       })
 
       if (response.ok) {
         const data = await response.json()
-        setJobData(data.jobs)
+        if (data.csv) {
+          setJobsCsv(data.csv)
+          const wb = XLSX.read(data.csv, { type: 'string' })
+          const sheet = wb.Sheets[wb.SheetNames[0]]
+          const rows = XLSX.utils.sheet_to_json<JobData>(sheet)
+          setJobData(rows as JobData[])
+        } else {
+          setJobData(data.jobs)
+        }
       } else {
         console.error("Failed to process job data")
       }
@@ -72,7 +102,9 @@ export default function JobMatchingApp() {
   }
 
   const processApplicantData = async () => {
-    if (!applicantText.trim()) return
+    if (!applicantFile) return
+    const text = await readUpload(applicantFile)
+    if (!text) return
 
     setIsApplicantProcessing(true)
     try {
@@ -81,12 +113,20 @@ export default function JobMatchingApp() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ text: applicantText }),
+        body: JSON.stringify({ text }),
       })
 
       if (response.ok) {
         const data = await response.json()
-        setApplicantData([data.applicant])
+        if (data.csv) {
+          setSeekersCsv(data.csv)
+          const wb = XLSX.read(data.csv, { type: 'string' })
+          const sheet = wb.Sheets[wb.SheetNames[0]]
+          const rows = XLSX.utils.sheet_to_json<ApplicantData>(sheet)
+          setApplicantData(rows as ApplicantData[])
+        } else {
+          setApplicantData([data.applicant])
+        }
       } else {
         console.error("Failed to process applicant data")
       }
@@ -98,10 +138,13 @@ export default function JobMatchingApp() {
   }
 
   const executeMatching = async () => {
-    if (jobData.length === 0 || applicantData.length === 0) {
-      alert("求人データと求職者データの両方を入力・変換してください")
+    if (!matchJobsFile || !matchSeekersFile) {
+      alert("求人CSVと求職者CSVの両方をアップロードしてください")
       return
     }
+    const jobsCsvText = await readUpload(matchJobsFile)
+    const seekersCsvText = await readUpload(matchSeekersFile)
+    if (!jobsCsvText || !seekersCsvText) return
 
     setIsMatching(true)
     try {
@@ -110,15 +153,19 @@ export default function JobMatchingApp() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          jobs: jobData,
-          applicant: applicantData[0],
-        }),
+        body: JSON.stringify({ jobs_csv: jobsCsvText, seekers_csv: seekersCsvText }),
       })
 
       if (response.ok) {
         const data = await response.json()
-        setMatchResults(data.matches)
+        if (data.csv) {
+          const wb = XLSX.read(data.csv, { type: 'string' })
+          const sheet = wb.Sheets[wb.SheetNames[0]]
+          const rows = XLSX.utils.sheet_to_json<MatchResult>(sheet)
+          setMatchResults(rows as MatchResult[])
+        } else {
+          setMatchResults(data.matches)
+        }
         setShowMatchResults(true)
       } else {
         console.error("Failed to execute matching")
@@ -161,15 +208,14 @@ export default function JobMatchingApp() {
 
               <TabsContent value="jobs" className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium mb-2">求人情報（複数件対応）</label>
-                  <Textarea
-                    placeholder="ここに求人情報を複数件貼り付けてください&#10;&#10;例：&#10;【求人1】&#10;職種：Webエンジニア&#10;会社：株式会社テック&#10;場所：東京都渋谷区&#10;給与：年収400-600万円&#10;必要スキル：React, Node.js, TypeScript&#10;&#10;【求人2】&#10;職種：データサイエンティスト&#10;会社：AI株式会社&#10;..."
-                    value={jobText}
-                    onChange={(e) => setJobText(e.target.value)}
-                    className="min-h-[200px] resize-y"
+                  <label className="block text-sm font-medium mb-2">求人データファイル (.txt, .csv, .xlsx)</label>
+                  <input
+                    type="file"
+                    accept=".txt,.csv,.xlsx,.xls"
+                    onChange={(e) => setJobFile(e.target.files?.[0] || null)}
                   />
                 </div>
-                <Button onClick={processJobData} disabled={isJobProcessing || !jobText.trim()} className="w-full">
+                <Button onClick={processJobData} disabled={isJobProcessing || !jobFile} className="w-full">
                   {isJobProcessing ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -215,17 +261,16 @@ export default function JobMatchingApp() {
 
               <TabsContent value="applicant" className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium mb-2">求職者情報（1人分）</label>
-                  <Textarea
-                    placeholder="ここに1人分の求職者情報を貼り付けてください&#10;&#10;例：&#10;名前：田中太郎&#10;スキル：React, Vue.js, Python, SQL&#10;経験：Webエンジニア3年、フロントエンド開発メイン&#10;希望勤務地：東京都内&#10;希望年収：500万円以上"
-                    value={applicantText}
-                    onChange={(e) => setApplicantText(e.target.value)}
-                    className="min-h-[200px] resize-y"
+                  <label className="block text-sm font-medium mb-2">求職者データファイル (.txt, .csv, .xlsx)</label>
+                  <input
+                    type="file"
+                    accept=".txt,.csv,.xlsx,.xls"
+                    onChange={(e) => setApplicantFile(e.target.files?.[0] || null)}
                   />
                 </div>
                 <Button
                   onClick={processApplicantData}
-                  disabled={isApplicantProcessing || !applicantText.trim()}
+                  disabled={isApplicantProcessing || !applicantFile}
                   className="w-full"
                 >
                   {isApplicantProcessing ? (
@@ -281,10 +326,28 @@ export default function JobMatchingApp() {
             <CardDescription>入力されたデータを基にAIがマッチング分析を実行します</CardDescription>
           </CardHeader>
           <CardContent>
+            <div className="space-y-2">
+              <div>
+                <label className="block text-sm font-medium mb-1">求人CSV</label>
+                <input
+                  type="file"
+                  accept=".txt,.csv,.xlsx,.xls"
+                  onChange={(e) => setMatchJobsFile(e.target.files?.[0] || null)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">求職者CSV</label>
+                <input
+                  type="file"
+                  accept=".txt,.csv,.xlsx,.xls"
+                  onChange={(e) => setMatchSeekersFile(e.target.files?.[0] || null)}
+                />
+              </div>
+            </div>
             <Button
               onClick={executeMatching}
-              disabled={isMatching || jobData.length === 0 || applicantData.length === 0}
-              className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
+              disabled={isMatching || !matchJobsFile || !matchSeekersFile}
+              className="w-full mt-4 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
               size="lg"
             >
               {isMatching ? (
@@ -300,9 +363,9 @@ export default function JobMatchingApp() {
               )}
             </Button>
 
-            {(jobData.length === 0 || applicantData.length === 0) && (
+            {(!matchJobsFile || !matchSeekersFile) && (
               <p className="text-sm text-gray-500 mt-2 text-center">
-                求人データと求職者データの両方を変換してからマッチングを実行してください
+                求人CSVと求職者CSVを選択してからマッチングを実行してください
               </p>
             )}
           </CardContent>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
+    "xlsx": "^0.18.5",
     "zod": "^3.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `xlsx` dependency
- support reading txt/csv/xlsx files in UI
- use uploaded CSV files for matching
- adjust API route to send `jobs_csv` and `seekers_csv`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f0109c0832998c0b0db8388bcd6